### PR TITLE
Fix gulpfile syntax.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -5,7 +5,7 @@ var del = require("del"),
     svgmin = require("gulp-svgmin"),
     path = require("path");
 
-gulp.task("clean", () => {
+gulp.task("clean", function() {
     return del([
         "dist/**/*"
     ]);
@@ -18,15 +18,13 @@ gulp.task("export", shell.task([
         + path.resolve(__dirname, "src") + " "
 ]));
 
-gulp.task("svg", () => {
+gulp.task("svg", function() {
     return gulp.src("dist/**/*.svg")
         .pipe(svgmin())
         .pipe(gulp.dest("dist"));
 });
 
-gulp.task("default", done => {
-    runSequence("clean", "export", "svg", done);
-});
+gulp.task("default", ["clean", "export", "svg"]);
 
 
 


### PR DESCRIPTION
I was not able to run the `gulp` command, where I had errors caused by the gulpfile syntax. Here is an example. 

```
/local/path/to/repo/Gulpfile.js:21
gulp.task("svg", () => {
                  ^
SyntaxError: Unexpected token )
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Liftoff.handleArguments (/usr/local/lib/node_modules/gulp/bin/gulp.js:116:3)
    at Liftoff.<anonymous> (/usr/local/lib/node_modules/gulp/node_modules/liftoff/index.js:192:16)
    at module.exports (/usr/local/lib/node_modules/gulp/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
```

I updated and it worked like a charm for me. 
