### PR TITLE
Fix range on node engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-design-icons",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "IBM Icons",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "engines": {
-    "node": "^5.1.0"
+    "node": ">=5.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #62 

Hopefully addresses the issue discussed in #62 by just changing the version criteria from `^` to `>=`. 

Unable to verify locally since `npm link` doesn't seem to respect the `engines` field in `package.json` files 😔